### PR TITLE
Bugfix/widgets small size

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14,6 +14,7 @@
 #include <QFileDialog>
 #include <QHeaderView>
 #include <QMessageBox>
+#include <QScrollArea>
 #include <QSettings>
 #include <QStandardItemModel>
 #include <QStandardPaths>
@@ -161,9 +162,9 @@ MainWindow::Error MainWindow::importConfig(const QString &filename)
 
 void MainWindow::createWidgetRequested(QStandardItem *item)
 {
-    MdiChild *child;
-    auto whatsThis = item->whatsThis();
+    const auto whatsThis = item->whatsThis();
 
+    MdiChild *child;
     if (whatsThis.startsWith("block_") && !whatsThis.contains("group_")) {
         auto blockId = whatsThis.split('_').at(1).toInt();
         child        = new MdiChild(m_config->protocol.blocks.at(blockId));
@@ -172,8 +173,16 @@ void MainWindow::createWidgetRequested(QStandardItem *item)
         child        = new MdiChild(m_config->protocol.blocks.at(blockId));
     }
 
-    ui->mdiArea->addSubWindow(child);
-    child->show();
+    auto subWindow = new QWidget(ui->mdiArea);
+    subWindow->setWindowTitle(child->title());
+    subWindow->setLayout(new QVBoxLayout(subWindow));
+
+    auto scrollArea = new QScrollArea(subWindow);
+    subWindow->layout()->addWidget(scrollArea);
+    scrollArea->setWidget(child);
+
+    ui->mdiArea->addSubWindow(subWindow);
+    subWindow->show();
 }
 
 void MainWindow::saveSettings()

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -17,6 +17,12 @@
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
      <widget class="QMdiArea" name="mdiArea">
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAsNeeded</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAsNeeded</enum>
+      </property>
       <property name="documentMode">
        <bool>false</bool>
       </property>


### PR DESCRIPTION
When you keep don't window at full screen you may have a mdi child that are bigger than area available, with this patch a scrollbar is showed if it is necessary.